### PR TITLE
Fix/thinkphp table name

### DIFF
--- a/src/Command/ThinkPHPCommand.php
+++ b/src/Command/ThinkPHPCommand.php
@@ -53,8 +53,8 @@ class ThinkPHPCommand extends Command
         }
 
         foreach ($tables as $key => $table) {
-            file_put_contents( $migrationsPath. $key . date('YmdHis') . '_' . $table->getName(). '.php' , $migrateGenerator->getMigrationContent($table));
-
+            $fileName = Util::mapClassNameToFileName(Str::studly($table->getName()));
+            file_put_contents( $migrationsPath.$fileName,$migrateGenerator->getMigrationContent($table));
             $output->info(sprintf('%s table migration file generated', $table->getName()));
         }
     }

--- a/src/Command/ThinkPHPCommand.php
+++ b/src/Command/ThinkPHPCommand.php
@@ -54,7 +54,9 @@ class ThinkPHPCommand extends Command
 
         foreach ($tables as $key => $table) {
             $fileName = Util::mapClassNameToFileName(Str::studly($table->getName()));
+			
             file_put_contents( $migrationsPath.$fileName,$migrateGenerator->getMigrationContent($table));
+			
             $output->info(sprintf('%s table migration file generated', $table->getName()));
         }
     }


### PR DESCRIPTION
修改了table生成规则 和tp官方生成的文件一样 解决了think migrate:run操作时出现的顺序问题